### PR TITLE
pipe-markov-chain 1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 target/
-pom.xml.tag
-pom.xml.releaseBackup
-pom.xml.next
-release.properties
 
 .idea/
 *.iml

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ release.properties
 
 .idea/
 *.iml
+
+.settings
+.project
+.classpath

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- github server corresponds to entry in ~/.m2/settings.xml -->
         <github.global.server>github</github.global.server>
     </properties>
@@ -141,6 +142,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -154,6 +156,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.imperial</groupId>
     <artifactId>pipe-markov-chain</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.2</version>
 
 
     <scm>
@@ -15,7 +15,7 @@
     	   -Darguments=-Dgithub.site.repositoryOwner=sarahtattersall release:prepare (or release:perform) 
     	 -->
         <developerConnection>scm:git:git@github.com:${github.site.repositoryOwner}/PIPEMarkovChain.git</developerConnection>
-      <tag>HEAD</tag>
+      <tag>pipe-markov-chain--1.0.2</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>uk.ac.imperial</groupId>
     <artifactId>pipe-markov-chain</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3-SNAPSHOT</version>
 
 
     <scm>
@@ -15,7 +15,7 @@
     	   -Darguments=-Dgithub.site.repositoryOwner=sarahtattersall release:prepare (or release:perform) 
     	 -->
         <developerConnection>scm:git:git@github.com:${github.site.repositoryOwner}/PIPEMarkovChain.git</developerConnection>
-      <tag>pipe-markov-chain--1.0.2</tag>
+      <tag>HEAD</tag>
   </scm>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,13 @@
 
 
     <scm>
-        <developerConnection>scm:git:git@github.com:sarahtattersall/PIPEMarkovChain.git</developerConnection>
+    	<!-- 
+    	   Used by maven release plugin.  
+    	   Add -Darguments=-Dgithub.site.repositoryOwner=yourGithubUserId to 
+    	   maven release plugin commands, e.g., 
+    	   -Darguments=-Dgithub.site.repositoryOwner=sarahtattersall release:prepare (or release:perform) 
+    	 -->
+        <developerConnection>scm:git:git@github.com:${github.site.repositoryOwner}/PIPEMarkovChain.git</developerConnection>
       <tag>HEAD</tag>
   </scm>
 
@@ -78,9 +84,17 @@
             </plugin>
 
             <plugin>
+       	    	<!-- 
+		    	   Used by maven release plugin, and as part of deploy phase.  
+		    	   For the release plugin, any command line arguments must be passed using -Darguments="args... "
+		    	   Add -Darguments=-Dgithub.site.repositoryOwner=yourGithubUserId to maven release commands, e.g., 
+			    	   -Darguments=-Dgithub.site.repositoryOwner=sarahtattersall release:prepare (or release:perform, or deploy)
+			       For the deploy phase, -Darguments is not needed:
+			       	   -Dgithub.site.repositoryOwner=sarahtattersall clean deploy  
+	        	 -->
                 <groupId>com.github.github</groupId>
                 <artifactId>site-maven-plugin</artifactId>
-                <version>0.9</version>
+                <version>0.12</version>
                 <configuration>
                     <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
                     <noJekyll>true</noJekyll>                                  <!-- disable webpage processing -->
@@ -88,7 +102,7 @@
                     <branch>refs/heads/mvn-repo</branch>                       <!-- remote branch name -->
                     <includes><include>**/*</include></includes>
                     <repositoryName>PIPEMarkovChain</repositoryName>      <!-- github repo name -->
-                    <repositoryOwner>sarahtattersall</repositoryOwner>    <!-- github username  -->
+                    <repositoryOwner>${github.site.repositoryOwner}</repositoryOwner>    <!-- github username, was sarahtattersall  -->
                     <merge>true</merge> <!-- Keep all releases -->
                 </configuration>
                 <executions>
@@ -103,11 +117,27 @@
             </plugin>
 
             <plugin>
+               <!-- this version and maven-scm-provider-gitexe 1.8.1 correctly 
+               generate a release jar rather than a SNAPSHOT jar, but 
+               do not correctly distinguish branch and tag by the same name
+               so force an extra "-" in the tagNameFormat to keep them unique
+               later versions of the two plugins (e.g., 2.5.3 and 1.9.4) 
+               distinguish them via refs/heads/xxx and refs/tags/xxx but don't 
+               yet fix the original problem of generating a SNAPSHOT jar.  -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.4.2</version>
+                  <configuration>
+          			<tagNameFormat>@{project.artifactId}--@{project.version}</tagNameFormat>
+        		  </configuration>
+			      <dependencies>
+			        <dependency>
+			          <groupId>org.apache.maven.scm</groupId>
+			          <artifactId>maven-scm-provider-gitexe</artifactId>
+			          <version>1.8.1</version>
+			        </dependency>
+			       </dependencies>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>


### PR DESCRIPTION
Generalize the release process, by enabling an arbitrary user to run the maven release plugin.  Assumes a pull request will then be created to merge the user's changes into Sarah's original repository.  See pom.xml for the necessary command line flags.  